### PR TITLE
pull_spec: pull #2 so it works on linux too

### DIFF
--- a/Library/Homebrew/test/dev-cmd/pull_spec.rb
+++ b/Library/Homebrew/test/dev-cmd/pull_spec.rb
@@ -10,13 +10,10 @@ describe "brew pull", :integration_test do
       .and not_to_output.to_stdout
       .and be_a_failure
 
-    # Needs Homebrew/homebrew-core
-    if OS.mac?
-      expect { brew "pull", "1" }
-        .to output(/Fetching patch/).to_stdout
-        .and output(/Current branch is new\-branch/).to_stderr
-        .and be_a_failure
-    end
+    expect { brew "pull", "2" }
+      .to output(/Fetching patch/).to_stdout
+      .and output(/Current branch is new\-branch/).to_stderr
+      .and be_a_failure
 
     expect { brew "pull", "--bump", "https://api.github.com/repos/Homebrew/homebrew-core/pulls/122" }
       .to output(/Fetching patch/).to_stdout


### PR DESCRIPTION
- [X] Have you followed the guidelines in our [Contributing](https://github.com/Homebrew/brew/blob/master/CONTRIBUTING.md) document?
- [X] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/Homebrew/brew/pulls) for the same change?
- [X] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an example](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/test/PATH_spec.rb).
- [ ] Have you successfully run `brew style` with your changes locally?
- [ ] Have you successfully run `brew tests` with your changes locally?

-----

This is a follow-up to this conversation thread: https://github.com/Homebrew/brew/pull/5726#discussion_r259942109

I think the test expectation was passing on macOS but failing on Linux because Homebrew/homebrew-core#1  is a pull request but Homebrew/linuxbrew-core#1 is an issue. I haven't tested it, but I think changing it to `2` will work because Homebrew/homebrew-core#2 and Homebrew/linuxbrew-core#2 are both pull requests.